### PR TITLE
Fixed typo of input variable name in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   canary-task-idle-duration:
     description: "--canaryTaskIdleDuration for cage"
     required: false
-  envitonment:
+  environment:
     description: "Arbitrary release environment for github deployment. e.g. development,staging,production... Required by --create-deployment"
     required: false
   github-ref:


### PR DESCRIPTION
I found the following output in the GitHub Actions execution log.

```
Unexpected input 'environment', valid inputs are ['cage-version', 'deploy-context', 'region', 'create-deployment', 'envitonment', 'github-ref', 'github-repository', 'github-token']
```

The warning log seems to show that the input of the name "environment" is unknown, but the actual behavior of the action seems to be fine.
