### PR TITLE
misc: bump default cage version 3.3.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'LoiLo'
 inputs:
   cage-version:
     description: "Canarycage version"
-    default: "3.3.0"
+    default: "3.3.1"
     required: false
   deploy-context:
     description: "Directory path that contains service.json and task-definition.json. Mostly relative path from project root."


### PR DESCRIPTION
Updated the default version of canarycage to 3.3.1